### PR TITLE
feat: user activation via code

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -139,6 +139,28 @@ dnspython = ">=2.0.0"
 idna = ">=2.0.0"
 
 [[package]]
+name = "fakeredis"
+version = "2.23.3"
+description = "Python implementation of redis API, can be used for testing purposes."
+optional = false
+python-versions = "<4.0,>=3.7"
+files = [
+    {file = "fakeredis-2.23.3-py3-none-any.whl", hash = "sha256:4779be828f4ebf53e1a286fd11e2ffe0f510d3e5507f143d644e67a07387d759"},
+    {file = "fakeredis-2.23.3.tar.gz", hash = "sha256:0c67caa31530114f451f012eca920338c5eb83fa7f1f461dd41b8d2488a99cba"},
+]
+
+[package.dependencies]
+redis = ">=4"
+sortedcontainers = ">=2,<3"
+
+[package.extras]
+bf = ["pyprobables (>=0.6,<0.7)"]
+cf = ["pyprobables (>=0.6,<0.7)"]
+json = ["jsonpath-ng (>=1.6,<2.0)"]
+lua = ["lupa (>=2.1,<3.0)"]
+probabilistic = ["pyprobables (>=0.6,<0.7)"]
+
+[[package]]
 name = "fastapi"
 version = "0.111.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -999,6 +1021,21 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "5.0.7"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "redis-5.0.7-py3-none-any.whl", hash = "sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db"},
+    {file = "redis-5.0.7.tar.gz", hash = "sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b"},
+]
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+
+[[package]]
 name = "rich"
 version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -1096,6 +1133,17 @@ python-versions = ">=3.7"
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -1650,4 +1698,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "60fb42c02edb6cf9dda7b8d87182355d18eff0d4391ecbfbcf97448a8e4138ed"
+content-hash = "60173c010c98e39ccf15072df68ec908290622a5f2326bf714e805abfa808dc4"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,8 @@ psycopg2-binary = "^2.9.9"
 alembic = "^1.13.1"
 pyjwt = "^2.8.0"
 slowapi = "^0.1.9"
+redis = "^5.0.7"
+fakeredis = "^2.23.3"
 
 [tool.poetry.group.dev.dependencies]
 setuptools = "^69.5.1"

--- a/backend/src/bootstrap.py
+++ b/backend/src/bootstrap.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import Any, Callable
 
+from src.common.adapters.activation_code_storage import ActivationCodeStorage
+from src.common.dependencies.activation_code_generator import ActivationCodeGenerator
 from src.common.dependencies.notificator import Notificator
 from src.common.dependencies.password_hash_util import PasswordHashUtil
 from src.common.dependencies.token_manager import TokenManager
@@ -89,6 +91,8 @@ def create_dependencies_dict(
     uow: UnitOfWork,
     password_hash_util: PasswordHashUtil,
     uuid_generator: UUIDGenerator,
+    activation_code_generator: ActivationCodeGenerator,
+    activation_code_storage: ActivationCodeStorage,
     token_manager: TokenManager,
     notificator: Notificator,
 ) -> dict[str, Any]:
@@ -98,6 +102,8 @@ def create_dependencies_dict(
         "uow": uow,
         "password_hash_util": password_hash_util,
         "uuid_generator": uuid_generator,
+        "activation_code_generator": activation_code_generator,
+        "activation_code_storage": activation_code_storage,
         "token_manager": token_manager,
         "notificator": notificator,
     }

--- a/backend/src/common/adapters/activation_code_storage.py
+++ b/backend/src/common/adapters/activation_code_storage.py
@@ -1,0 +1,11 @@
+import abc
+
+
+class ActivationCodeStorage(abc.ABC):
+    @abc.abstractmethod
+    def get_activation_code(self, username: str) -> str:
+        pass
+
+    @abc.abstractmethod
+    def save_activation_code(self, username: str, code: str) -> None:
+        pass

--- a/backend/src/common/adapters/activation_code_storage.py
+++ b/backend/src/common/adapters/activation_code_storage.py
@@ -3,7 +3,7 @@ import abc
 
 class ActivationCodeStorage(abc.ABC):
     @abc.abstractmethod
-    def get_activation_code(self, username: str) -> str:
+    def get_activation_code(self, username: str) -> None | str:
         pass
 
     @abc.abstractmethod

--- a/backend/src/common/dependencies/activation_code_generator.py
+++ b/backend/src/common/dependencies/activation_code_generator.py
@@ -1,0 +1,13 @@
+import abc
+from random import random
+
+
+class ActivationCodeGenerator(abc.ABC):
+    @abc.abstractmethod
+    def create_code(self) -> str:
+        pass
+
+
+class RandomActivationCodeGenerator(ActivationCodeGenerator):
+    def create_code(self) -> str:
+        return str(10000000 + int(1000000000 * random()))

--- a/backend/src/common/dependencies/notificator.py
+++ b/backend/src/common/dependencies/notificator.py
@@ -11,12 +11,11 @@ class Notificator(abc.ABC):
         self, recipient: "User", subject: str, message: str
     ) -> None: ...
 
-    def send_activation_link(self, recipient: "User", activation_token: str):
-        link = f"{config.get_base_url()}/activate/{activation_token}"
+    def send_activation_code(self, recipient: "User", activation_code: str):
         self.send_notification(
             recipient=recipient,
             subject="WannaBuyThis Account activation",
-            message=f"Activate your account by clicking on this link: {link}",
+            message=f"Activation code: {activation_code}",
         )
 
 

--- a/backend/src/common/service/exceptions.py
+++ b/backend/src/common/service/exceptions.py
@@ -71,6 +71,11 @@ class PasswordVerificationError(VerificationException):
         super().__init__(error_message)
 
 
+class CodeVerificationError(VerificationException):
+    def __init__(self, error_message: str = "Code does not match"):
+        super().__init__(error_message)
+
+
 class WishlistNotFound(NotFoundException):
     def __init__(self, uuid: UUID):
         super().__init__(f"Wishlist '{uuid}' not found")

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -40,3 +40,9 @@ def get_auth_token_lifetime() -> datetime.timedelta:
 def get_activation_token_lifetime() -> datetime.timedelta:
     token_lifetime_in_hours = os.environ.get("ACTIVATION_TOKEN_LIFETIME_IN_HOURS", "24")
     return datetime.timedelta(hours=int(token_lifetime_in_hours))
+
+
+# Redis config
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+REDIS_PORT = os.environ.get("REDIS_PORT", 6379)
+REDIS_ACTIVATION_CODES_DB = os.environ.get("REDIS_ACTIVATION_CODES_DB", 0)

--- a/backend/src/integration/adapters/redis/activation_code_storage.py
+++ b/backend/src/integration/adapters/redis/activation_code_storage.py
@@ -1,0 +1,21 @@
+import redis
+
+from src import config
+
+
+class RedisActivationCodeStorage:
+    def __init__(self, redis_client: redis.Redis = None):
+        if redis_client:
+            self.redis_client = redis_client
+        else:
+            self.redis_client = redis.Redis(
+                host=config.REDIS_HOST,
+                port=config.REDIS_PORT,
+                db=config.REDIS_ACTIVATION_CODES_DB,
+            )
+
+    def get_activation_code(self, username: str) -> str:
+        return self.redis_client.get(username)
+
+    def save_activation_code(self, username: str, code: str) -> None:
+        self.redis_client.set(username, code)

--- a/backend/src/integration/adapters/redis/activation_code_storage.py
+++ b/backend/src/integration/adapters/redis/activation_code_storage.py
@@ -15,8 +15,11 @@ class RedisActivationCodeStorage(ActivationCodeStorage):
                 db=config.REDIS_ACTIVATION_CODES_DB,
             )
 
-    def get_activation_code(self, username: str) -> str:
-        return self.redis_client.get(username)
+    def get_activation_code(self, username: str) -> None | str:
+        code = self.redis_client.get(username)
+        if code is None:
+            return None
+        return code.decode()
 
     def save_activation_code(self, username: str, code: str) -> None:
         self.redis_client.set(username, code)

--- a/backend/src/integration/adapters/redis/activation_code_storage.py
+++ b/backend/src/integration/adapters/redis/activation_code_storage.py
@@ -1,9 +1,10 @@
 import redis
 
 from src import config
+from src.common.adapters.activation_code_storage import ActivationCodeStorage
 
 
-class RedisActivationCodeStorage:
+class RedisActivationCodeStorage(ActivationCodeStorage):
     def __init__(self, redis_client: redis.Redis = None):
         if redis_client:
             self.redis_client = redis_client

--- a/backend/src/users/domain/commands.py
+++ b/backend/src/users/domain/commands.py
@@ -24,8 +24,9 @@ class ActivateUser(Command):
 
 
 @dataclass(frozen=True)
-class ActivateUserWithToken(Command):
-    token: str
+class ActivateUserWithCode(Command):
+    username: str
+    code: str
 
 
 @dataclass(frozen=True)

--- a/backend/src/users/domain/commands.py
+++ b/backend/src/users/domain/commands.py
@@ -29,7 +29,7 @@ class ActivateUserWithToken(Command):
 
 
 @dataclass(frozen=True)
-class ResendActivationLink(Command):
+class ResendActivationCode(Command):
     username: str
     password: str
 

--- a/backend/src/users/entrypoints/fastapi/_pydantic_models.py
+++ b/backend/src/users/entrypoints/fastapi/_pydantic_models.py
@@ -17,6 +17,11 @@ class UserResponse(BaseModel):
     is_active: bool
 
 
+class ActivateUserWithCodeRequest(BaseModel):
+    username: str
+    code: str
+
+
 class ChangePasswordByUserRequest(BaseModel):
     old_password: str
     new_password: str

--- a/backend/src/users/entrypoints/fastapi/auth_router.py
+++ b/backend/src/users/entrypoints/fastapi/auth_router.py
@@ -8,12 +8,13 @@ from starlette.status import HTTP_200_OK
 from src import config
 from src.common.entrypoints.fastapi_limiter import limiter
 from src.users.domain.commands import (
-    ActivateUserWithToken,
+    ActivateUserWithCode,
     CreateUser,
     GenerateAuthToken,
     ResendActivationCode,
 )
 from src.users.entrypoints.fastapi._pydantic_models import (
+    ActivateUserWithCodeRequest,
     CreateUserResponse,
     LoginUserResponse,
 )
@@ -44,9 +45,11 @@ def register(command: CreateUser, request: Request):
     return {"message": "User created successfully"}
 
 
-@users_auth_router.get("/activate/{activation_token}", status_code=HTTP_200_OK)
-def activate_user(activation_token: str, request: Request):
-    request.app.state.messagebus.handle(ActivateUserWithToken(activation_token))
+@users_auth_router.post("/activate", status_code=HTTP_200_OK)
+def activate_user(body_data: ActivateUserWithCodeRequest, request: Request):
+    request.app.state.messagebus.handle(
+        ActivateUserWithCode(username=body_data.username, code=body_data.code)
+    )
 
 
 @users_auth_router.post("/resend-activation", status_code=HTTP_200_OK)

--- a/backend/src/users/entrypoints/fastapi/auth_router.py
+++ b/backend/src/users/entrypoints/fastapi/auth_router.py
@@ -11,7 +11,7 @@ from src.users.domain.commands import (
     ActivateUserWithToken,
     CreateUser,
     GenerateAuthToken,
-    ResendActivationLink,
+    ResendActivationCode,
 )
 from src.users.entrypoints.fastapi._pydantic_models import (
     CreateUserResponse,
@@ -49,7 +49,12 @@ def activate_user(activation_token: str, request: Request):
     request.app.state.messagebus.handle(ActivateUserWithToken(activation_token))
 
 
-@users_auth_router.post("/activate/resend-activation-link", status_code=HTTP_200_OK)
+@users_auth_router.post("/resend-activation", status_code=HTTP_200_OK)
 @limiter.limit("5/minute")
-def resend_activation_link(command: ResendActivationLink, request: Request):
+def resend_activation_code(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()], request: Request
+):
+    command = ResendActivationCode(
+        username=form_data.username, password=form_data.password
+    )
     request.app.state.messagebus.handle(command)

--- a/backend/src/users/service/event_handlers.py
+++ b/backend/src/users/service/event_handlers.py
@@ -1,5 +1,6 @@
+from src.common.adapters.activation_code_storage import ActivationCodeStorage
+from src.common.dependencies.activation_code_generator import ActivationCodeGenerator
 from src.common.dependencies.notificator import Notificator
-from src.common.dependencies.token_manager import TokenManager
 from src.common.domain.events import DomainEvent
 from src.common.service.uow import UnitOfWork
 from src.users.domain.events import (
@@ -9,19 +10,23 @@ from src.users.domain.events import (
     UserCreated,
     UserDeactivated,
 )
-from src.users.service.handlers_utils import send_notification_with_activation_link
+from src.users.service.handlers_utils import send_new_activation_code
 
 
 def handle_user_created(
     event: UserCreated,
     uow: UnitOfWork,
     notificator: Notificator,
-    token_manager: TokenManager,
+    activation_code_generator: ActivationCodeGenerator,
+    activation_code_storage: ActivationCodeStorage,
 ):
     with uow:
         user = uow.user_repository.get(event.username)
-    send_notification_with_activation_link(
-        notificator=notificator, token_manager=token_manager, user=user
+    send_new_activation_code(
+        user=user,
+        activation_code_generator=activation_code_generator,
+        activation_code_storage=activation_code_storage,
+        notificator=notificator,
     )
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,9 @@ from sqlalchemy import StaticPool, create_engine
 from sqlalchemy.orm import clear_mappers, sessionmaker
 
 from src import bootstrap
+from src.common.dependencies.activation_code_generator import (
+    RandomActivationCodeGenerator,
+)
 from src.common.dependencies.password_hash_util import HashlibPasswordHashUtil
 from src.common.dependencies.token_manager import JWTManager
 from src.common.dependencies.uuid_generator import DefaultUUIDGenerator
@@ -15,7 +18,7 @@ from src.integration.adapters.sqlalchemy_orm import (
 from src.integration.service.sqlalchemy_uow import SQLAlchemyUnitOfWork
 from src.users.domain.model import User
 from src.wishlists.domain.model import MeasurementUnit, Priority, Wishlist, WishlistItem
-from tests.fakes import FakeNotificator, FakeUnitOfWork
+from tests.fakes import FakeActivationCodeStorage, FakeNotificator, FakeUnitOfWork
 
 
 @pytest.fixture
@@ -148,6 +151,8 @@ def messagebus():
         uow=FakeUnitOfWork(),
         password_hash_util=HashlibPasswordHashUtil(),
         uuid_generator=DefaultUUIDGenerator(),
+        activation_code_generator=RandomActivationCodeGenerator(),
+        activation_code_storage=FakeActivationCodeStorage(),
         token_manager=JWTManager(),
         notificator=FakeNotificator(),
     )

--- a/backend/tests/e2e/test_fastapi_users.py
+++ b/backend/tests/e2e/test_fastapi_users.py
@@ -6,7 +6,7 @@ CHANGE_EMAIL_URL = "/users/change-email"
 CHANGE_PASSWORD_URL = "/users/change-password"
 REGISTER_URL = "/register"
 ACTIVATE_WITH_TOKEN_URL = "/activate"
-RESEND_ACTIVATION_TOKEN_URL = "/activate/resend-activation-link"
+RESEND_ACTIVATION_URL = "/resend-activation"
 LOGIN_URL = "/login"
 GET_CURRENT_USER_URL = "/users/me"
 GET_USER_URL = "/users"
@@ -68,9 +68,9 @@ class TestFastAPIUsersAuthRoutes:
     def test_resend_activation_link(
         self, client_with_deactivated_user, deactivated_user, valid_password
     ):
-        body = {"username": deactivated_user.username, "password": valid_password}
+        form_data = {"username": deactivated_user.username, "password": valid_password}
         response = client_with_deactivated_user.post(
-            RESEND_ACTIVATION_TOKEN_URL, json=body
+            RESEND_ACTIVATION_URL, data=form_data
         )
         assert response.status_code == 200
 

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -73,8 +73,11 @@ class FakeActivationCodeStorage(ActivationCodeStorage):
     def __init__(self):
         self._activation_codes = dict()
 
-    def get_activation_code(self, username: str) -> str:
-        return self._activation_codes[username]
+    def get_activation_code(self, username: str) -> None | str:
+        try:
+            return self._activation_codes[username]
+        except KeyError:
+            return None
 
     def save_activation_code(self, username: str, code: str) -> None:
         self._activation_codes[username] = code

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from src.common.adapters.activation_code_storage import ActivationCodeStorage
 from src.common.dependencies.notificator import Notificator
 from src.common.service.exceptions import UserNotFound, WishlistNotFound
 from src.common.service.uow import UnitOfWork
@@ -66,3 +67,14 @@ class FakeNotificator(Notificator):
         print(
             f"Fake notificator: {recipient.username} ({recipient.email}), {subject}, {message}"
         )
+
+
+class FakeActivationCodeStorage(ActivationCodeStorage):
+    def __init__(self):
+        self._activation_codes = dict()
+
+    def get_activation_code(self, username: str) -> str:
+        return self._activation_codes[username]
+
+    def save_activation_code(self, username: str, code: str) -> None:
+        self._activation_codes[username] = code

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture
+def redis_client():
+    import fakeredis
+
+    redis_client = fakeredis.FakeRedis()
+    return redis_client
+
+
+@pytest.fixture
+def redis_activation_code_storage(redis_client):
+    from src.integration.adapters.redis.activation_code_storage import (
+        RedisActivationCodeStorage,
+    )
+
+    return RedisActivationCodeStorage(redis_client)

--- a/backend/tests/integration/redis/test_activation_code_storage.py
+++ b/backend/tests/integration/redis/test_activation_code_storage.py
@@ -1,0 +1,13 @@
+class TestRedisActivationCodeStorage:
+    USERNAME = "username"
+    CODE = b"12345678"
+
+    def test_get_activation_code(self, redis_client, redis_activation_code_storage):
+        redis_client.set(self.USERNAME, self.CODE)
+        assert (
+            redis_activation_code_storage.get_activation_code(self.USERNAME) == self.CODE
+        )
+
+    def test_save_activation_code(self, redis_client, redis_activation_code_storage):
+        redis_activation_code_storage.save_activation_code(self.USERNAME, self.CODE)
+        assert redis_client.get(self.USERNAME) == self.CODE

--- a/backend/tests/integration/redis/test_activation_code_storage.py
+++ b/backend/tests/integration/redis/test_activation_code_storage.py
@@ -1,6 +1,6 @@
 class TestRedisActivationCodeStorage:
     USERNAME = "username"
-    CODE = b"12345678"
+    CODE = "12345678"
 
     def test_get_activation_code(self, redis_client, redis_activation_code_storage):
         redis_client.set(self.USERNAME, self.CODE)
@@ -11,4 +11,4 @@ class TestRedisActivationCodeStorage:
 
     def test_save_activation_code(self, redis_client, redis_activation_code_storage):
         redis_activation_code_storage.save_activation_code(self.USERNAME, self.CODE)
-        assert redis_client.get(self.USERNAME) == self.CODE
+        assert redis_client.get(self.USERNAME).decode() == self.CODE

--- a/backend/tests/integration/redis/test_activation_code_storage.py
+++ b/backend/tests/integration/redis/test_activation_code_storage.py
@@ -5,7 +5,8 @@ class TestRedisActivationCodeStorage:
     def test_get_activation_code(self, redis_client, redis_activation_code_storage):
         redis_client.set(self.USERNAME, self.CODE)
         assert (
-            redis_activation_code_storage.get_activation_code(self.USERNAME) == self.CODE
+            redis_activation_code_storage.get_activation_code(self.USERNAME)
+            == self.CODE
         )
 
     def test_save_activation_code(self, redis_client, redis_activation_code_storage):


### PR DESCRIPTION
Replaces activation by link (with the jwt token) with activation using the code passed in the body of the POST /activate.